### PR TITLE
Issue with file descriptors in OS

### DIFF
--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -178,7 +178,7 @@ func (c *Client) exec(req *request) (io.ReadCloser, error) {
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected http status code: %v", res.StatusCode)
 	}
-
+	res.Body.Close()
 	return res.Body, nil
 }
 

--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -178,7 +178,7 @@ func (c *Client) exec(req *request) (io.ReadCloser, error) {
 		res.Body.Close()
 		return nil, fmt.Errorf("unexpected http status code: %v", res.StatusCode)
 	}
-	res.Body.Close()
+	
 	return res.Body, nil
 }
 
@@ -198,10 +198,13 @@ func (c *Client) login() error {
 
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusUnauthorized {
+			res.Body.Close()
 			return unauthorizedHTTPResponseToFreeipaError(res)
 		}
+		res.Body.Close()
 		return fmt.Errorf("unexpected http status code: %v", res.StatusCode)
 	}
+	res.Body.Close()
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ccin2p3/go-freeipa
+module github.com/gladkovandrey/go-freeipa
 
 go 1.15
 


### PR DESCRIPTION
Hello. 
When I use your module in my code I have problem with file descriptors. I run my code as systemd service in Linux. After some time I see that service leave some open sockets. And later service spends all file descriptors and restart by error. I found that in your code when we call Login function we are not close res.Body. I added it in code and now all work as expected.
If something is not clear to understand please contact.