### PR TITLE
fix: set mandatory Referer header on login request

### DIFF
--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -65,6 +65,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 
 	k5client "github.com/jcmturner/gokrb5/v8/client"
 	k5config "github.com/jcmturner/gokrb5/v8/config"
@@ -190,7 +191,16 @@ func (c *Client) login() error {
 		"user":     []string{c.user},
 		"password": []string{c.pw},
 	}
-	res, e := c.hc.PostForm(fmt.Sprintf("https://%v/ipa/session/login_password", c.host), data)
+
+	req, e := http.NewRequest(http.MethodPost, fmt.Sprintf("https://%v/ipa/session/login_password", c.host), strings.NewReader(data.Encode()))
+	if e != nil {
+		return errors.WithMessage(e, "building login HTTP request")
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Referer", fmt.Sprintf("https://%s/ipa", c.host))
+
+	res, e := c.hc.Do(req)
 	if e != nil {
 		return e
 	}

--- a/freeipa/client.go
+++ b/freeipa/client.go
@@ -62,7 +62,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -130,7 +129,7 @@ func ConnectWithKerberos(host string, tspt http.RoundTripper, k5ConnectOpts *Ker
 		return nil, errors.WithMessage(err, "reading kerberos configuration")
 	}
 
-	ktBytes, err := ioutil.ReadAll(k5ConnectOpts.KeytabReader)
+	ktBytes, err := io.ReadAll(k5ConnectOpts.KeytabReader)
 	if err != nil {
 		return nil, errors.WithMessage(err, "reading keytab")
 	}

--- a/gen/dirty_overrides.go
+++ b/gen/dirty_overrides.go
@@ -33,7 +33,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 type DirtyOverrides struct {
@@ -61,7 +61,7 @@ func (c ClassParamsOverrides) OverrideParams(p *Param) {
 
 func loadDirtyOverrides() (DirtyOverrides, error) {
 	var overrides DirtyOverrides
-	in, e := ioutil.ReadFile("../data/dirty_overrides.json")
+	in, e := os.ReadFile("../data/dirty_overrides.json")
 	if e != nil {
 		return overrides, e
 	}

--- a/gen/main.go
+++ b/gen/main.go
@@ -33,7 +33,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -89,7 +88,7 @@ func actualMain() error {
 }
 
 func loadSchema(localOverrides DirtyOverrides) (*Schema, error) {
-	input, e := ioutil.ReadFile("../data/schema.json")
+	input, e := os.ReadFile("../data/schema.json")
 	if e != nil {
 		return nil, e
 	}
@@ -247,7 +246,7 @@ func loadSchema(localOverrides DirtyOverrides) (*Schema, error) {
 }
 
 func loadErrs() ([]ErrDesc, error) {
-	in, e := ioutil.ReadFile("../data/errors.json")
+	in, e := os.ReadFile("../data/errors.json")
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
This header is now mandatory to address CVE-2023-5455: https://github.com/freeipa/freeipa/commit/13778d88ca2ac73b729821bdea844172a18c0cb9.